### PR TITLE
Draft: Add Metrics

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,16 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise();
+});

--- a/examples/qd_rng_2.py
+++ b/examples/qd_rng_2.py
@@ -8,10 +8,9 @@ import jax.random
 import numpy as np
 import tqdm
 
-
 from qdglue.tasks.kheperax.task import KheperaxTask
-from qdglue.tasks.linear_projection import LinearProjection
 from qdglue.tasks.knights_tour import KnightsTour
+from qdglue.tasks.linear_projection import LinearProjection
 from qdglue.tasks.strawman_task import StrawMan
 
 
@@ -38,7 +37,9 @@ def main(task: str = "linear_projection", iterations: int = 1000, batch_size: in
         raise ValueError(f"Unknown task `{task}`")
 
     for itr in tqdm.trange(iterations):
-        parameters = task_instance.get_initial_parameters(seed=42, number_parameters=batch_size)
+        parameters = task_instance.get_initial_parameters(
+            seed=42, number_parameters=batch_size
+        )
 
         if task_instance.parameter_type == "discrete":
             parameters = np.floor(parameters).astype(int)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,8 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
 markdown_extensions:
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.highlight
   - pymdownx.superfences
 theme:
@@ -37,3 +39,7 @@ theme:
 extra_css:
   - css/custom.css
   - css/mkdocstrings.css
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

--- a/qdglue/metrics/grid_based_metrics.py
+++ b/qdglue/metrics/grid_based_metrics.py
@@ -10,21 +10,22 @@ from qdglue.types import Feature, Fitness
 
 @dataclasses.dataclass
 class DiscreteArchiveMetrics:
-    """Holds statistics about an archive."""
+    """Holds statistics about an archive.
 
-    # Proportion of cells in the archive that have an elite - always in the
-    # range :math:`[0,1]`.
+    Attributes:
+        coverage: Proportion of cells in the archive that have an elite - always
+            in the range $[0,1]$.
+        qd_score: QD score, i.e. sum of objective values of all elites in the
+            archive. All the fitnesses are normalized to $[0,1]$ using the
+            fitness_bounds before computing the QD score.
+        max_fitness: Maximum objective value of the elites in the archive.
+        ccdf: Complementary Cumulative Distribution of Fitness from Vassiliades
+            et al. (2018)
+    """
+
     coverage: float
-
-    # QD score, i.e. sum of objective values of all elites in the archive.
-    # all the fitnesses are normalized to [0,1] using the fitness_bounds
-    # before computing the QD score.
     qd_score: float
-
-    # Maximum objective value of the elites in the archive.
     max_fitness: float
-
-    # Complementary Cumulative Distribution of Fitness from Vassiliades et al. (2018)
     ccdf: np.ndarray
 
 

--- a/qdglue/metrics/grid_based_metrics.py
+++ b/qdglue/metrics/grid_based_metrics.py
@@ -11,6 +11,7 @@ from qdglue.types import Feature, Fitness
 @dataclasses.dataclass
 class DiscreteArchiveMetrics:
     """Holds statistics about an archive."""
+
     # Proportion of cells in the archive that have an elite - always in the
     # range :math:`[0,1]`.
     coverage: float
@@ -28,24 +29,25 @@ class DiscreteArchiveMetrics:
 
 
 class DiscreteArchiveMetricsCalculator(ABC):
-    def __init__(self,
-                 fitness_bounds: gymnasium.spaces.Box,
-                 num_points_ccdf: int = 100,
-                 ):
+    def __init__(
+        self,
+        fitness_bounds: gymnasium.spaces.Box,
+        num_points_ccdf: int = 100,
+    ):
         assert np.all(np.isfinite(fitness_bounds.low)) and np.all(
             np.isfinite(fitness_bounds.high)
         ), "Fitness bounds must be finite"
         assert (
-                np.prod(fitness_bounds.shape) == 1
+            np.prod(fitness_bounds.shape) == 1
         ), "Only scalar fitnesses are supported for now"
 
         self.fitness_bounds = fitness_bounds
         self.num_points_ccdf = num_points_ccdf
 
     def get_metrics(
-            self,
-            fitnesses: Fitness,
-            features: Feature,
+        self,
+        fitnesses: Fitness,
+        features: Feature,
     ) -> DiscreteArchiveMetrics:
         self._check_validity_features(features)
         self._check_validity_fitnesses(fitnesses)
@@ -54,7 +56,7 @@ class DiscreteArchiveMetricsCalculator(ABC):
         # The empty cells do not appear in the best_fitnesses array
         best_fitnesses = self._extract_best_fitnesses_per_cell(fitnesses, features)
         best_fitnesses_normalized = (best_fitnesses - self.fitness_bounds.low) / (
-                self.fitness_bounds.high - self.fitness_bounds.low
+            self.fitness_bounds.high - self.fitness_bounds.low
         )
         # TODO(looka): support case where fitness_bounds.high == +inf, and just apply the offset in that case?
 
@@ -76,8 +78,8 @@ class DiscreteArchiveMetricsCalculator(ABC):
         )
 
     def _compute_ccdf(
-            self,
-            best_fitnesses: Fitness,
+        self,
+        best_fitnesses: Fitness,
     ) -> np.ndarray:
         fitnesses_intermediate = np.linspace(
             start=self.fitness_bounds.low,
@@ -114,9 +116,9 @@ class DiscreteArchiveMetricsCalculator(ABC):
 
     @abstractmethod
     def _extract_best_fitnesses_per_cell(
-            self,
-            fitnesses: Fitness,
-            features: Feature,
+        self,
+        fitnesses: Fitness,
+        features: Feature,
     ) -> Fitness:
         """
         Returns an array of the best fitnesses per cell.
@@ -125,8 +127,13 @@ class DiscreteArchiveMetricsCalculator(ABC):
 
 
 class GridMetricsCalculator(DiscreteArchiveMetricsCalculator):
-    def __init__(self, feature_space: gymnasium.spaces.Box, fitness_bounds: gymnasium.spaces.Box,
-                 resolution: Tuple[int, ...], num_points_ccdf: int = 100):
+    def __init__(
+        self,
+        feature_space: gymnasium.spaces.Box,
+        fitness_bounds: gymnasium.spaces.Box,
+        resolution: Tuple[int, ...],
+        num_points_ccdf: int = 100,
+    ):
         super().__init__(fitness_bounds, num_points_ccdf)
         self.feature_space = feature_space
 
@@ -137,9 +144,9 @@ class GridMetricsCalculator(DiscreteArchiveMetricsCalculator):
         self.resolution = resolution
 
     def _extract_best_fitnesses_per_cell(
-            self,
-            fitnesses: Fitness,
-            features: Feature,
+        self,
+        fitnesses: Fitness,
+        features: Feature,
     ) -> Fitness:
         """
         Returns an array of the best fitnesses per cell.
@@ -150,9 +157,9 @@ class GridMetricsCalculator(DiscreteArchiveMetricsCalculator):
         resolution_array = np.asarray(self.resolution, dtype=np.int32)
 
         features_multi_indexes = (
-                resolution_array
-                * (features - self.feature_space.low)
-                / (self.feature_space.high - self.feature_space.low)
+            resolution_array
+            * (features - self.feature_space.low)
+            / (self.feature_space.high - self.feature_space.low)
         )
         features_multi_indexes = np.floor(features_multi_indexes).astype(np.int32)
 
@@ -186,11 +193,12 @@ class GridMetricsCalculator(DiscreteArchiveMetricsCalculator):
 
 
 class CVTMetricsCalculator(DiscreteArchiveMetricsCalculator):
-    def __init__(self,
-                 fitness_bounds: gymnasium.spaces.Box,
-                 centroids: Feature,
-                 num_points_ccdf: int = 100,
-                 ):
+    def __init__(
+        self,
+        fitness_bounds: gymnasium.spaces.Box,
+        centroids: Feature,
+        num_points_ccdf: int = 100,
+    ):
         super().__init__(fitness_bounds, num_points_ccdf)
 
         self.centroids = centroids
@@ -206,10 +214,11 @@ class CVTMetricsCalculator(DiscreteArchiveMetricsCalculator):
         distances = np.linalg.norm(self.centroids - feature, axis=1)
         return np.argmin(distances).item()
 
-    def _extract_best_fitnesses_per_cell(self,
-                                         fitnesses: Fitness,
-                                         features: Feature,
-                                         ) -> Fitness:
+    def _extract_best_fitnesses_per_cell(
+        self,
+        fitnesses: Fitness,
+        features: Feature,
+    ) -> Fitness:
         """
         Returns an array of the best fitnesses per cell.
         The empty cells do not appear in the returned array.
@@ -244,9 +253,7 @@ def example_grid_based_metrics():
 
     metrics = calculator.get_metrics(
         fitnesses=np.array([0.3, 0.5, 0.7]),
-        features=np.array([[0.55, 0.55],
-                           [0.55, 0.551],
-                           [0.3, 0.3]]),
+        features=np.array([[0.55, 0.55], [0.55, 0.551], [0.3, 0.3]]),
     )
 
     print("Grid based metrics:", metrics)
@@ -255,11 +262,14 @@ def example_grid_based_metrics():
 def example_cvt_based_metrics():
     fitness_bounds = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(1,))
 
-    centroids = np.array([[0.1, 0.1],
-                          [0.9, 0.9],
-                          [0.1, 0.9],
-                          [0.9, 0.1],
-                          ])
+    centroids = np.array(
+        [
+            [0.1, 0.1],
+            [0.9, 0.9],
+            [0.1, 0.9],
+            [0.9, 0.1],
+        ]
+    )
 
     calculator = CVTMetricsCalculator(
         fitness_bounds=fitness_bounds,
@@ -268,9 +278,7 @@ def example_cvt_based_metrics():
 
     metrics = calculator.get_metrics(
         fitnesses=np.array([0.3, 0.5, 0.7]),
-        features=np.array([[0.9, 0.9],
-                           [0.9, 0.91],
-                           [0.3, 0.3]]),
+        features=np.array([[0.9, 0.9], [0.9, 0.91], [0.3, 0.3]]),
     )
 
     print("CVT based metrics:", metrics)

--- a/qdglue/metrics/grid_based_metrics.py
+++ b/qdglue/metrics/grid_based_metrics.py
@@ -1,0 +1,281 @@
+import dataclasses
+from abc import ABC, abstractmethod
+from typing import Dict, Tuple
+
+import gymnasium
+import numpy as np
+
+from qdglue.types import Feature, Fitness
+
+
+@dataclasses.dataclass
+class DiscreteArchiveMetrics:
+    """Holds statistics about an archive."""
+    # Proportion of cells in the archive that have an elite - always in the
+    # range :math:`[0,1]`.
+    coverage: float
+
+    # QD score, i.e. sum of objective values of all elites in the archive.
+    # all the fitnesses are normalized to [0,1] using the fitness_bounds
+    # before computing the QD score.
+    qd_score: float
+
+    # Maximum objective value of the elites in the archive.
+    max_fitness: float
+
+    # Complementary Cumulative Distribution of Fitness from Vassiliades et al. (2018)
+    ccdf: np.ndarray
+
+
+class DiscreteArchiveMetricsCalculator(ABC):
+    def __init__(self,
+                 fitness_bounds: gymnasium.spaces.Box,
+                 num_points_ccdf: int = 100,
+                 ):
+        assert np.all(np.isfinite(fitness_bounds.low)) and np.all(
+            np.isfinite(fitness_bounds.high)
+        ), "Fitness bounds must be finite"
+        assert (
+                np.prod(fitness_bounds.shape) == 1
+        ), "Only scalar fitnesses are supported for now"
+
+        self.fitness_bounds = fitness_bounds
+        self.num_points_ccdf = num_points_ccdf
+
+    def get_metrics(
+            self,
+            fitnesses: Fitness,
+            features: Feature,
+    ) -> DiscreteArchiveMetrics:
+        self._check_validity_features(features)
+        self._check_validity_fitnesses(fitnesses)
+
+        # Extracting the best fitnesses per cell
+        # The empty cells do not appear in the best_fitnesses array
+        best_fitnesses = self._extract_best_fitnesses_per_cell(fitnesses, features)
+        best_fitnesses_normalized = (best_fitnesses - self.fitness_bounds.low) / (
+                self.fitness_bounds.high - self.fitness_bounds.low
+        )
+        # TODO(looka): support case where fitness_bounds.high == +inf, and just apply the offset in that case?
+
+        # Computing the metrics
+        total_cells = self.num_cells
+
+        coverage = np.size(best_fitnesses) / total_cells
+        max_fitness = np.max(best_fitnesses)
+        qd_score = np.sum(best_fitnesses_normalized).item()
+
+        # Computing the Complementary Cumulative Distribution of Fitness
+        ccdf = self._compute_ccdf(best_fitnesses)
+
+        return DiscreteArchiveMetrics(
+            coverage=coverage,
+            qd_score=qd_score,
+            max_fitness=max_fitness,
+            ccdf=ccdf,
+        )
+
+    def _compute_ccdf(
+            self,
+            best_fitnesses: Fitness,
+    ) -> np.ndarray:
+        fitnesses_intermediate = np.linspace(
+            start=self.fitness_bounds.low,
+            stop=self.fitness_bounds.high,
+            num=self.num_points_ccdf,
+            endpoint=True,
+        )
+
+        list_coverages_higher_than_fit = []
+
+        total_cells = self.num_cells
+
+        for _fit in fitnesses_intermediate:
+            coverage_higher_than_fit = np.sum(best_fitnesses >= _fit) / total_cells
+            list_coverages_higher_than_fit.append(coverage_higher_than_fit)
+
+        ccdf = np.asarray(list_coverages_higher_than_fit)
+
+        return ccdf
+
+    @property
+    @abstractmethod
+    def num_cells(self) -> int:
+        """Number of cells in the grid."""
+
+    @abstractmethod
+    def _check_validity_features(self, features: Feature) -> None:
+        """Check validity of features."""
+
+    def _check_validity_fitnesses(self, fitnesses):
+        assert np.all(np.min(fitnesses, axis=0) >= self.fitness_bounds.low) and np.all(
+            np.max(fitnesses, axis=0) <= self.fitness_bounds.high
+        ), "Fitnesses must be within the fitness bounds"
+
+    @abstractmethod
+    def _extract_best_fitnesses_per_cell(
+            self,
+            fitnesses: Fitness,
+            features: Feature,
+    ) -> Fitness:
+        """
+        Returns an array of the best fitnesses per cell.
+        The empty cells do not appear in the returned array.
+        """
+
+
+class GridMetricsCalculator(DiscreteArchiveMetricsCalculator):
+    def __init__(self, feature_space: gymnasium.spaces.Box, fitness_bounds: gymnasium.spaces.Box,
+                 resolution: Tuple[int, ...], num_points_ccdf: int = 100):
+        super().__init__(fitness_bounds, num_points_ccdf)
+        self.feature_space = feature_space
+
+        assert np.all(np.isfinite(self.feature_space.low)) and np.all(
+            np.isfinite(self.feature_space.high)
+        ), "Feature space bounds must be finite"
+
+        self.resolution = resolution
+
+    def _extract_best_fitnesses_per_cell(
+            self,
+            fitnesses: Fitness,
+            features: Feature,
+    ) -> Fitness:
+        """
+        Returns an array of the best fitnesses per cell.
+        The empty cells do not appear in the returned array.
+        """
+
+        # First, we need to convert the features to single-number indexes in the grid
+        resolution_array = np.asarray(self.resolution, dtype=np.int32)
+
+        features_multi_indexes = (
+                resolution_array
+                * (features - self.feature_space.low)
+                / (self.feature_space.high - self.feature_space.low)
+        )
+        features_multi_indexes = np.floor(features_multi_indexes).astype(np.int32)
+
+        features_indexes = np.ravel_multi_index(
+            multi_index=features_multi_indexes.T, dims=self.resolution, mode="raise"
+        )  # TODO check this line
+
+        # Collecting the best fitnesses per feature index
+        best_fitness_per_feature_index: Dict[int, Fitness] = dict()
+
+        for index_feature, fitness in zip(features_indexes, fitnesses):
+            if index_feature not in best_fitness_per_feature_index:
+                best_fitness_per_feature_index[index_feature] = fitness
+            else:
+                best_fitness_per_feature_index[index_feature] = np.maximum(
+                    best_fitness_per_feature_index[index_feature], fitness
+                )
+
+        best_fitnesses = np.asarray(list(best_fitness_per_feature_index.values()))
+
+        return best_fitnesses
+
+    @property
+    def num_cells(self) -> int:
+        return np.prod(self.resolution).astype(np.int32).item()
+
+    def _check_validity_features(self, features: Feature) -> None:
+        assert np.all(np.min(features, axis=0) >= self.feature_space.low) and np.all(
+            np.max(features, axis=0) <= self.feature_space.high
+        ), "Features must be within the feature space bounds"
+
+
+class CVTMetricsCalculator(DiscreteArchiveMetricsCalculator):
+    def __init__(self,
+                 fitness_bounds: gymnasium.spaces.Box,
+                 centroids: Feature,
+                 num_points_ccdf: int = 100,
+                 ):
+        super().__init__(fitness_bounds, num_points_ccdf)
+
+        self.centroids = centroids
+
+    @property
+    def num_cells(self) -> int:
+        return self.centroids.shape[0]
+
+    def _check_validity_features(self, features: Feature) -> None:
+        pass
+
+    def _get_index_closest_centroid(self, feature: Feature) -> int:
+        distances = np.linalg.norm(self.centroids - feature, axis=1)
+        return np.argmin(distances).item()
+
+    def _extract_best_fitnesses_per_cell(self,
+                                         fitnesses: Fitness,
+                                         features: Feature,
+                                         ) -> Fitness:
+        """
+        Returns an array of the best fitnesses per cell.
+        The empty cells do not appear in the returned array.
+        """
+
+        best_fitness_per_centroid_index: Dict[int, Fitness] = dict()
+
+        for feature, fitness in zip(features, fitnesses):
+            index_closest_centroid = self._get_index_closest_centroid(feature)
+            if index_closest_centroid not in best_fitness_per_centroid_index:
+                best_fitness_per_centroid_index[index_closest_centroid] = fitness
+            else:
+                best_fitness_per_centroid_index[index_closest_centroid] = np.maximum(
+                    best_fitness_per_centroid_index[index_closest_centroid], fitness
+                )
+
+        best_fitnesses = np.asarray(list(best_fitness_per_centroid_index.values()))
+
+        return best_fitnesses
+
+
+def example_grid_based_metrics():
+    feature_space = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(2,))
+    fitness_bounds = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(1,))
+    resolution = (10, 10)
+
+    calculator = GridMetricsCalculator(
+        feature_space=feature_space,
+        fitness_bounds=fitness_bounds,
+        resolution=resolution,
+    )
+
+    metrics = calculator.get_metrics(
+        fitnesses=np.array([0.3, 0.5, 0.7]),
+        features=np.array([[0.55, 0.55],
+                           [0.55, 0.551],
+                           [0.3, 0.3]]),
+    )
+
+    print("Grid based metrics:", metrics)
+
+
+def example_cvt_based_metrics():
+    fitness_bounds = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(1,))
+
+    centroids = np.array([[0.1, 0.1],
+                          [0.9, 0.9],
+                          [0.1, 0.9],
+                          [0.9, 0.1],
+                          ])
+
+    calculator = CVTMetricsCalculator(
+        fitness_bounds=fitness_bounds,
+        centroids=centroids,
+    )
+
+    metrics = calculator.get_metrics(
+        fitnesses=np.array([0.3, 0.5, 0.7]),
+        features=np.array([[0.9, 0.9],
+                           [0.9, 0.91],
+                           [0.3, 0.3]]),
+    )
+
+    print("CVT based metrics:", metrics)
+
+
+if __name__ == "__main__":
+    example_grid_based_metrics()
+    example_cvt_based_metrics()

--- a/qdglue/metrics/grid_based_metrics.py
+++ b/qdglue/metrics/grid_based_metrics.py
@@ -26,7 +26,7 @@ class DiscreteArchiveMetrics:
         max_fitness: Maximum objective value of the elites in the archive.
         ccdf: Complementary Cumulative Distribution of Fitness from Vassiliades
             et al. (2018)
-        discrete_archive_metrics_functor: The metrics functor that was used
+        discrete_archive_metrics_calculator: The metrics functor that was used
             to compute the metrics.
     """
 
@@ -36,20 +36,20 @@ class DiscreteArchiveMetrics:
     max_fitness: float
     ccdf: np.ndarray
 
-    discrete_archive_metrics_functor: DiscreteArchiveMetricsFunctor
+    discrete_archive_metrics_calculator: DiscreteArchiveMetricsCalculator
 
     @property
     def ccdf_fitness_bins(self) -> np.ndarray:
         """Returns the evaluation positions of the ."""
         return np.linspace(
-            start=self.discrete_archive_metrics_functor.fitness_bounds.low.item(),
-            stop=self.discrete_archive_metrics_functor.fitness_bounds.high.item(),
-            num=self.discrete_archive_metrics_functor.num_points_ccdf,
+            start=self.discrete_archive_metrics_calculator.fitness_bounds.low.item(),
+            stop=self.discrete_archive_metrics_calculator.fitness_bounds.high.item(),
+            num=self.discrete_archive_metrics_calculator.num_points_ccdf,
             endpoint=True,
         )
 
 
-class DiscreteArchiveMetricsFunctor(ABC):
+class DiscreteArchiveMetricsCalculator(ABC):
     def __init__(
         self,
         fitness_bounds: gymnasium.spaces.Box,
@@ -105,7 +105,7 @@ class DiscreteArchiveMetricsFunctor(ABC):
             qd_score_bound_norm=qd_score_bound_norm,
             max_fitness=max_fitness,
             ccdf=ccdf,
-            discrete_archive_metrics_functor=self,
+            discrete_archive_metrics_calculator=self,
         )
 
     def _compute_ccdf(
@@ -151,7 +151,7 @@ class DiscreteArchiveMetricsFunctor(ABC):
         """
 
 
-class GridMetricsFunctor(DiscreteArchiveMetricsFunctor):
+class GridMetricsCalculator(DiscreteArchiveMetricsCalculator):
     def __init__(
         self,
         feature_space: gymnasium.spaces.Box,
@@ -217,7 +217,7 @@ class GridMetricsFunctor(DiscreteArchiveMetricsFunctor):
         ), "Features must be within the feature space bounds"
 
 
-class CVTMetricsFunctor(DiscreteArchiveMetricsFunctor):
+class CVTMetricsCalculator(DiscreteArchiveMetricsCalculator):
     def __init__(
         self,
         fitness_bounds: gymnasium.spaces.Box,

--- a/qdglue/tasks/kheperax/geoms.py
+++ b/qdglue/tasks/kheperax/geoms.py
@@ -4,7 +4,6 @@ import flax.struct
 import jax
 import jax.numpy as jnp
 
-
 from qdglue.tasks.kheperax.posture import Posture
 
 

--- a/qdglue/tasks/kheperax/laser.py
+++ b/qdglue/tasks/kheperax/laser.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import flax.struct
 import jax
 from jax import numpy as jnp
+
 from qdglue.tasks.kheperax.geoms import Pos, Segment
 
 

--- a/qdglue/tasks/kheperax/maze.py
+++ b/qdglue/tasks/kheperax/maze.py
@@ -6,7 +6,7 @@ import flax.struct
 import jax.tree_util
 from jax import numpy as jnp
 
-from qdglue.tasks.kheperax.geoms import Segment, Pos
+from qdglue.tasks.kheperax.geoms import Pos, Segment
 
 
 @flax.struct.dataclass

--- a/qdglue/tasks/kheperax/rendering_tools.py
+++ b/qdglue/tasks/kheperax/rendering_tools.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+
 from qdglue.tasks.kheperax.geoms import Pos, Segment
 
 

--- a/qdglue/tasks/kheperax/robot.py
+++ b/qdglue/tasks/kheperax/robot.py
@@ -7,8 +7,7 @@ import jax.lax
 import jax.tree_util
 from jax import numpy as jnp
 
-
-from qdglue.tasks.kheperax.geoms import Pos, Disk, Segment
+from qdglue.tasks.kheperax.geoms import Disk, Pos, Segment
 from qdglue.tasks.kheperax.laser import Laser
 from qdglue.tasks.kheperax.maze import Maze
 from qdglue.tasks.kheperax.posture import Posture

--- a/qdglue/tasks/kheperax/tree_utils.py
+++ b/qdglue/tasks/kheperax/tree_utils.py
@@ -1,6 +1,5 @@
 import jax
 import jax.numpy as jnp
-
 from jax.flatten_util import ravel_pytree
 
 

--- a/qdglue/tasks/knights_tour.py
+++ b/qdglue/tasks/knights_tour.py
@@ -95,6 +95,9 @@ class KnightsTour(QDTask):
             are: ["hand", "vae"]
     """
 
+    # TODO(rboldi): Is parameter_space_dims supposed to be here? It's not in the
+    # method definition.
+
     def __init__(self, method):
         super().__init__()
 

--- a/qdglue/tasks/knights_tour.py
+++ b/qdglue/tasks/knights_tour.py
@@ -1,6 +1,5 @@
 """Knight's Tour benchmark."""
 import gymnasium
-
 import numpy as np
 import torch
 import torch.nn as nn
@@ -119,7 +118,11 @@ class KnightsTour(QDTask):
         if method == "vae":
             # todo (rboldi) figure out how to do gpu stuff between jax and pytorch
             self.fitness_model = VariationalAutoencoder(8, device)
-            self.fitness_model.load_state_dict(torch.load("qdglue/tasks/vae_model.pt", map_location=torch.device(device)))
+            self.fitness_model.load_state_dict(
+                torch.load(
+                    "qdglue/tasks/vae_model.pt", map_location=torch.device(device)
+                )
+            )
             self.fitness_model = self.fitness_model.to(device)
             self.fitness_model.eval()
             self.fitness_model.freeze_encoder()
@@ -223,4 +226,6 @@ class KnightsTour(QDTask):
 
     @property
     def parameter_space(self) -> gymnasium.spaces.Space:
-        return gymnasium.spaces.MultiDiscrete(nvec=[8 for _ in range(self._parameter_space_dims)],)
+        return gymnasium.spaces.MultiDiscrete(
+            nvec=[8 for _ in range(self._parameter_space_dims)],
+        )

--- a/qdglue/tasks/linear_projection.py
+++ b/qdglue/tasks/linear_projection.py
@@ -16,11 +16,12 @@ class LinearProjection(QDTask):
 
     @property
     def parameter_space(self) -> gymnasium.spaces.Space:
-        return gymnasium.spaces.Box(low=-np.inf,
-                                    high=np.inf,
-                                    shape=(self._parameter_space_dims,),
-                                    dtype=np.float32,
-                                    )
+        return gymnasium.spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(self._parameter_space_dims,),
+            dtype=np.float32,
+        )
 
     def __init__(self, parameter_space_dims, function):
         super().__init__()

--- a/qdglue/tasks/qd_task.py
+++ b/qdglue/tasks/qd_task.py
@@ -45,7 +45,7 @@ class QDTask(ABC):
         Args:
             parameters: A batch of parameters to evaluate.
             random_key: Pseudo-random generator key (Mostly useful for JAX random number
-            generation)
+                generation)
         Returns:
             (batch_of_fitness, batch_of_descriptors, dict containing batch of extra_data)
         """

--- a/qdglue/tasks/qd_task.py
+++ b/qdglue/tasks/qd_task.py
@@ -4,6 +4,7 @@ from typing import Dict, Tuple
 
 import gymnasium
 import numpy as np
+
 #  import jax as jax
 #  import jax.numpy as jnp
 #  import numpy as np
@@ -17,7 +18,6 @@ from numpy.typing import ArrayLike
 #
 # I will argue that we should make an exception for NumPy because it is so
 # universal, but we can also aim to eliminate it as well.
-
 
 
 class QDTask(ABC):

--- a/qdglue/tasks/strawman_task.py
+++ b/qdglue/tasks/strawman_task.py
@@ -94,8 +94,9 @@ class StrawMan(QDTask):
 
     @property
     def parameter_space(self) -> gymnasium.spaces.Space:
-        return gymnasium.spaces.Box(low=-np.inf,
-                                    high=np.inf,
-                                    shape=(self._parameter_space_dims,),
-                                    dtype=np.float32,
-                                    )
+        return gymnasium.spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(self._parameter_space_dims,),
+            dtype=np.float32,
+        )

--- a/qdglue/types.py
+++ b/qdglue/types.py
@@ -5,9 +5,13 @@ from typing import Dict, Generic, TypeVar, Union
 import brax.envs
 import jax
 import jax.numpy as jnp
+
 import numpy as np
+from numpy.typing import ArrayLike
+
 from chex import ArrayTree
 from typing_extensions import TypeAlias
+
 
 # MDP types
 Observation: TypeAlias = jnp.ndarray
@@ -19,7 +23,8 @@ Params: TypeAlias = ArrayTree
 
 # Evolution types
 StateDescriptor: TypeAlias = jnp.ndarray
-Fitness: TypeAlias = jnp.ndarray
+Fitness: TypeAlias = ArrayLike
+Feature: TypeAlias = ArrayLike
 Genotype: TypeAlias = ArrayTree
 Descriptor: TypeAlias = jnp.ndarray
 Centroid: TypeAlias = jnp.ndarray

--- a/qdglue/types.py
+++ b/qdglue/types.py
@@ -1,42 +1,19 @@
 """Defines some types used in QDax"""
 
-from typing import Dict, Generic, TypeVar, Union
+from typing import Dict
 
-import brax.envs
 import jax
 import jax.numpy as jnp
-
 import numpy as np
-from numpy.typing import ArrayLike
-
 from chex import ArrayTree
 from typing_extensions import TypeAlias
 
-
-# MDP types
-Observation: TypeAlias = jnp.ndarray
-Action: TypeAlias = jnp.ndarray
-Reward: TypeAlias = jnp.ndarray
-Done: TypeAlias = jnp.ndarray
-EnvState: TypeAlias = brax.envs.State
-Params: TypeAlias = ArrayTree
-
 # Evolution types
-StateDescriptor: TypeAlias = jnp.ndarray
-Fitness: TypeAlias = ArrayLike
-Feature: TypeAlias = ArrayLike
-Genotype: TypeAlias = ArrayTree
-Descriptor: TypeAlias = jnp.ndarray
-Centroid: TypeAlias = jnp.ndarray
-Gradient: TypeAlias = jnp.ndarray
+Fitness: TypeAlias = np.ndarray
+Feature: TypeAlias = np.ndarray
+Centroid: TypeAlias = np.ndarray
 
-Skill: TypeAlias = jnp.ndarray
-
-ExtraScores: TypeAlias = Dict[str, ArrayTree]
 Info: TypeAlias = Dict[str, ArrayTree]
-
-Mask: TypeAlias = jnp.ndarray
 
 # Others
 RNGKey: TypeAlias = jax.random.KeyArray
-Metrics: TypeAlias = Dict[str, jnp.ndarray]

--- a/tests/tasks/discrete_metrics_tests.py
+++ b/tests/tasks/discrete_metrics_tests.py
@@ -6,14 +6,14 @@ from qdglue.metrics.grid_based_metrics import CVTMetricsFunctor, GridMetricsFunc
 
 def test_grid_based_metrics():
     feature_space = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(2,))
-    fitness_bounds = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(1,))
+    fitness_bounds = gymnasium.spaces.Box(low=-1.0, high=1.0, shape=(1,))
     resolution = (2, 2)
 
     calculator = GridMetricsFunctor(
         feature_space=feature_space,
         fitness_bounds=fitness_bounds,
         resolution=resolution,
-        num_points_ccdf=5,
+        num_points_ccdf=11,
     )
 
     metrics = calculator.get_metrics(
@@ -23,12 +23,16 @@ def test_grid_based_metrics():
 
     assert metrics.max_fitness == 0.751
     assert metrics.coverage == 0.5
-    assert metrics.qd_score == 1.251
-    assert np.all(metrics.ccdf == np.array([0.5, 0.5, 0.5, 0.25, 0.0]))
+    assert metrics.qd_score_bound_norm == 3.251 / 2.0
+    assert metrics.qd_score_original == 3.251
+    assert np.all(
+        metrics.ccdf
+        == np.array([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.25, 0.0, 0.0])
+    )
 
 
 def test_cvt_based_metrics():
-    fitness_bounds = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(1,))
+    fitness_bounds = gymnasium.spaces.Box(low=-1.0, high=1.0, shape=(1,))
 
     centroids = np.array(
         [
@@ -42,7 +46,7 @@ def test_cvt_based_metrics():
     calculator = CVTMetricsFunctor(
         fitness_bounds=fitness_bounds,
         centroids=centroids,
-        num_points_ccdf=5,
+        num_points_ccdf=11,
     )
 
     metrics = calculator.get_metrics(
@@ -52,5 +56,9 @@ def test_cvt_based_metrics():
 
     assert metrics.max_fitness == 0.751
     assert metrics.coverage == 0.5
-    assert metrics.qd_score == 1.251
-    assert np.all(metrics.ccdf == np.array([0.5, 0.5, 0.5, 0.25, 0.0]))
+    assert metrics.qd_score_bound_norm == 3.251 / 2.0
+    assert metrics.qd_score_original == 3.251
+    assert np.all(
+        metrics.ccdf
+        == np.array([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.25, 0.0, 0.0])
+    )

--- a/tests/tasks/discrete_metrics_tests.py
+++ b/tests/tasks/discrete_metrics_tests.py
@@ -1,0 +1,56 @@
+import gymnasium
+import numpy as np
+
+from qdglue.metrics.grid_based_metrics import CVTMetricsFunctor, GridMetricsFunctor
+
+
+def test_grid_based_metrics():
+    feature_space = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(2,))
+    fitness_bounds = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(1,))
+    resolution = (2, 2)
+
+    calculator = GridMetricsFunctor(
+        feature_space=feature_space,
+        fitness_bounds=fitness_bounds,
+        resolution=resolution,
+        num_points_ccdf=5,
+    )
+
+    metrics = calculator.get_metrics(
+        fitnesses=np.array([0.3, 0.5, 0.751]),
+        features=np.array([[0.55, 0.55], [0.55, 0.551], [0.3, 0.3]]),
+    )
+
+    assert metrics.max_fitness == 0.751
+    assert metrics.coverage == 0.5
+    assert metrics.qd_score == 1.251
+    assert np.all(metrics.ccdf == np.array([0.5, 0.5, 0.5, 0.25, 0.0]))
+
+
+def test_cvt_based_metrics():
+    fitness_bounds = gymnasium.spaces.Box(low=0.0, high=1.0, shape=(1,))
+
+    centroids = np.array(
+        [
+            [0.1, 0.1],
+            [0.9, 0.9],
+            [0.1, 0.9],
+            [0.9, 0.1],
+        ]
+    )
+
+    calculator = CVTMetricsFunctor(
+        fitness_bounds=fitness_bounds,
+        centroids=centroids,
+        num_points_ccdf=5,
+    )
+
+    metrics = calculator.get_metrics(
+        fitnesses=np.array([0.3, 0.5, 0.751]),
+        features=np.array([[0.9, 0.9], [0.9, 0.91], [0.3, 0.3]]),
+    )
+
+    assert metrics.max_fitness == 0.751
+    assert metrics.coverage == 0.5
+    assert metrics.qd_score == 1.251
+    assert np.all(metrics.ccdf == np.array([0.5, 0.5, 0.5, 0.25, 0.0]))

--- a/tests/tasks/discrete_metrics_tests.py
+++ b/tests/tasks/discrete_metrics_tests.py
@@ -1,7 +1,10 @@
 import gymnasium
 import numpy as np
 
-from qdglue.metrics.grid_based_metrics import CVTMetricsFunctor, GridMetricsFunctor
+from qdglue.metrics.grid_based_metrics import (
+    CVTMetricsCalculator,
+    GridMetricsCalculator,
+)
 
 
 def test_grid_based_metrics():
@@ -9,7 +12,7 @@ def test_grid_based_metrics():
     fitness_bounds = gymnasium.spaces.Box(low=-1.0, high=1.0, shape=(1,))
     resolution = (2, 2)
 
-    calculator = GridMetricsFunctor(
+    calculator = GridMetricsCalculator(
         feature_space=feature_space,
         fitness_bounds=fitness_bounds,
         resolution=resolution,
@@ -43,7 +46,7 @@ def test_cvt_based_metrics():
         ]
     )
 
-    calculator = CVTMetricsFunctor(
+    calculator = CVTMetricsCalculator(
         fitness_bounds=fitness_bounds,
         centroids=centroids,
         num_points_ccdf=11,


### PR DESCRIPTION
## Description

Add Main Metrics calculators. 
For the moment, we have a main abstract class `DiscreteArchiveMetricsCalculator`, which has 2 children:
- `GridMetricsCalculator` (using a standard MAP-Elites grid)
- `CVTMetricsCalculator` (using a CVT grid)

Each instance of those classes has a method `get_metrics` which return a dataclass object `DiscreteArchiveMetrics` (greatly inspired by the `ArchiveStats` of `pyribs`).

## TODO

- [ ] Complete Docstrings
- [ ] (future) Continuous QD scores calculators.
- [ ] (future) Add similar metrics calculators using `jax` in a separate folder (would make the metrics calculation faster and easier to vectorise).

## Questions

- [ ] There are 2 ways to calculate the QD-Score in the litterature: (1) adding an offset to all fitnesses and summing them, and (2) normalizing the fitnesses given a lower and an upper bound. For the moment, I implemented it using (2) only. Should I also add (1) ?

## Status

- [x] I have read the guidelines in CONTRIBUTING.md
- [x] I have formatted my code using `black`
- [ ] I have tested my code by running `pytest`
- [ ] I have added a one-line description of my change to the changelog in
      `HISTORY.md`
- [ ] This PR is ready to go
